### PR TITLE
Johnpreed replacestate

### DIFF
--- a/MVCGrid/Interfaces/IMVCGridDefinition.cs
+++ b/MVCGrid/Interfaces/IMVCGridDefinition.cs
@@ -128,6 +128,10 @@ namespace MVCGrid.Interfaces
         /// </summary>
         AuthorizationType AuthorizationType { get; set; }
 
+        /// <summary>
+        /// Sets the browser navigation mode for the grid.  PreserveAllGridActions is the default.
+        /// </summary>
+        BrowserNavigationMode BrowserNavigationMode { get; set; }
 
         /// <summary>
         /// The list of configured rendering engines availble for this grid

--- a/MVCGrid/MVCGrid.csproj
+++ b/MVCGrid/MVCGrid.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Engine\GridEngine.cs" />
     <Compile Include="Interfaces\IMVCGridRenderingEngine.cs" />
     <Compile Include="Interfaces\IMVCGridTemplatingEngine.cs" />
+    <Compile Include="Models\BrowserNavigationMode.cs" />
     <Compile Include="Models\AuthorizationType.cs" />
     <Compile Include="Models\ColumnDefaults.cs" />
     <Compile Include="Models\ColumnVisibility.cs" />

--- a/MVCGrid/Models/BrowserNavigationMode.cs
+++ b/MVCGrid/Models/BrowserNavigationMode.cs
@@ -1,0 +1,9 @@
+﻿
+namespace MVCGrid.Models
+{
+    public enum BrowserNavigationMode
+    {
+        PreserveAllGridActions,
+        PreserveLatestGridAction
+    }
+}

--- a/MVCGrid/Models/GridDefaults.cs
+++ b/MVCGrid/Models/GridDefaults.cs
@@ -34,6 +34,7 @@ namespace MVCGrid.Models
             AllowChangingPageSize = false;
             MaxItemsPerPage = null;
             AuthorizationType = Models.AuthorizationType.AllowAnonymous;
+            BrowserNavigationMode = Models.BrowserNavigationMode.PreserveAllGridActions;
 
             RenderingEngines = new ProviderSettingsCollection();
             RenderingEngines.Add(new ProviderSettings("BootstrapRenderingEngine", "MVCGrid.Rendering.BootstrapRenderingEngine, MVCGrid"));
@@ -103,6 +104,8 @@ namespace MVCGrid.Models
         }
 
         public AuthorizationType AuthorizationType { get; set; }
+
+        public BrowserNavigationMode BrowserNavigationMode { get; set; }
 
         public ProviderSettingsCollection RenderingEngines { get; set; }
         public string DefaultRenderingEngineName { get; set; }

--- a/MVCGrid/Models/GridDefinition.cs
+++ b/MVCGrid/Models/GridDefinition.cs
@@ -52,6 +52,7 @@ namespace MVCGrid.Models
             this.AllowChangingPageSize = gridDefaults.AllowChangingPageSize;
             this.MaxItemsPerPage = gridDefaults.MaxItemsPerPage;
             this.AuthorizationType = gridDefaults.AuthorizationType;
+            this.BrowserNavigationMode = gridDefaults.BrowserNavigationMode;
 
             this.RenderingEngines = gridDefaults.RenderingEngines;
             this.DefaultRenderingEngineName = gridDefaults.DefaultRenderingEngineName;
@@ -329,6 +330,11 @@ namespace MVCGrid.Models
         /// Indicated the authorization type. Anonymous access is the default.
         /// </summary>
         public AuthorizationType AuthorizationType { get; set; }
+
+        /// <summary>
+        /// Sets the browser navigation mode for the grid.  PreserveAllGridActions is the default.
+        /// </summary>
+        public BrowserNavigationMode BrowserNavigationMode { get; set; }
 
         public ProviderSettingsCollection RenderingEngines { get; set; }
         public string DefaultRenderingEngineName { get; set; }

--- a/MVCGrid/Models/MVCGridBuilder.cs
+++ b/MVCGrid/Models/MVCGridBuilder.cs
@@ -429,5 +429,14 @@ namespace MVCGrid.Models
             GridDefinition.AuthorizationType = authType;
             return this;
         }
+
+        /// <summary>
+        /// Sets the browser navigation mode for the grid.  PreserveAllGridActions is the default.
+        /// </summary>
+        public MVCGridBuilder<T1> WithBrowserNavigationMode(BrowserNavigationMode mode)
+        {
+            GridDefinition.BrowserNavigationMode = mode;
+            return this;
+        }
     }
 }

--- a/MVCGrid/Scripts/MVCGrid.js
+++ b/MVCGrid/Scripts/MVCGrid.js
@@ -378,8 +378,8 @@ var MVCGrid = new function () {
     // private
     var setURLAndReload = function (mvcGridName, newUrl) {
 
-        if (history.pushState) {
-            window.history.pushState({ path: newUrl }, '', newUrl);
+        if (history.replaceState) {
+            window.history.replaceState({ path: newUrl }, '', newUrl);
             MVCGrid.reloadGrid(mvcGridName);
         }
         else {

--- a/MVCGrid/Scripts/MVCGrid.js
+++ b/MVCGrid/Scripts/MVCGrid.js
@@ -378,8 +378,8 @@ var MVCGrid = new function () {
     // private
     var setURLAndReload = function (mvcGridName, newUrl) {
 
-        if (history.replaceState) {
-            window.history.replaceState({ path: newUrl }, '', newUrl);
+        if (history.pushState) {
+            window.history.pushState({ path: newUrl }, '', newUrl);
             MVCGrid.reloadGrid(mvcGridName);
         }
         else {

--- a/MVCGrid/Scripts/MVCGrid.js
+++ b/MVCGrid/Scripts/MVCGrid.js
@@ -378,8 +378,14 @@ var MVCGrid = new function () {
     // private
     var setURLAndReload = function (mvcGridName, newUrl) {
 
-        if (history.pushState) {
+        var gridDef = findGridDef(mvcGridName);
+        
+        if (gridDef.browserNavigationMode === 'preserveallgridactions' && history.pushState) {
             window.history.pushState({ path: newUrl }, '', newUrl);
+            MVCGrid.reloadGrid(mvcGridName);
+
+        } else if (history.replaceState) {
+            window.history.replaceState({ path: newUrl }, '', newUrl);
             MVCGrid.reloadGrid(mvcGridName);
         }
         else {

--- a/MVCGrid/Web/MVCGridHtmlGenerator.cs
+++ b/MVCGrid/Web/MVCGridHtmlGenerator.cs
@@ -226,6 +226,9 @@ namespace MVCGrid.Web
             sbJson.AppendFormat("\"renderingMode\": \"{0}\"", def.RenderingMode.ToString().ToLower());
 
             sbJson.Append(",");
+            sbJson.AppendFormat("\"browserNavigationMode\": \"{0}\"", def.BrowserNavigationMode.ToString().ToLower());
+
+            sbJson.Append(",");
             sbJson.Append("\"pageParameters\": {");
             sbJson.Append(GenerateJsonPageParameters(pageParameters));
             sbJson.Append("}");


### PR DESCRIPTION
Now supports both pushState and replaceState when performing an action
on the grid by defining the BrowserNavigationMode.  Defaults to
pushState, which was the original implementation.  if you only want to
preserve latest action on your grid, then set
.WithBrowserNavigationMode(BrowserNavigationMode.PreserveLatestGridAction)